### PR TITLE
Add lecture 11 materials: slides and CNN explainer link

### DIFF
--- a/F25/page/tables/lectures_table.html
+++ b/F25/page/tables/lectures_table.html
@@ -494,8 +494,12 @@
                     </td>
                     <td>
                         
+                        <a href="./document/slides/lec11.CNN3.pdf" target="_blank">Slides</a>
+                        
                     </td>
                     <td>
+                        
+                        <a href="https://poloclub.github.io/cnn-explainer/" target="_blank">CNN Explainer</a>
                         
                     </td>
                      

--- a/F25/page/tables_data/lectures.yaml
+++ b/F25/page/tables_data/lectures.yaml
@@ -264,8 +264,12 @@ lectures:
     date: "Monday,<br> Sep 29"
     topics:
       - "CNNs III"
-    slides_videos: []
-    additional_materials: []
+    slides_videos: 
+      - text: "Slides"
+        url: "./document/slides/lec11.CNN3.pdf"
+    additional_materials: 
+    - text: "CNN Explainer"
+      url: "https://poloclub.github.io/cnn-explainer/"
     quiz:
       text: "Quiz 6"
       rowspan: 2


### PR DESCRIPTION
- Updated lectures_table.html to include a link to the slides for lecture 11 (CNNs III).
- Modified lectures.yaml to add the slides and additional materials with corresponding URLs for lecture 11.