### PR TITLE
Add Fall 2026 lecture video links

### DIFF
--- a/F26/pages/tables/lectures_table.html
+++ b/F26/pages/tables/lectures_table.html
@@ -43,9 +43,7 @@
                         
                         <a href="https://docs.google.com/presentation/d/1A0L9bH6cpl7lDfrLmr6zg97ys7dagvPg/edit?slide=id.p39#slide=id.p39" target="_blank">Slides</a><br>
                         
-                        <a href="https://www.youtube.com/watch?v=_GMenT2mLnA" target="_blank">YouTube</a><br>
-                        
-                        <a href="" target="_blank">MediaService</a>
+                        <a href="https://www.youtube.com/watch?v=_GMenT2mLnA" target="_blank">YouTube</a>
                         
                     </td>
                     <td>

--- a/F26/pages/tables/lectures_table.html
+++ b/F26/pages/tables/lectures_table.html
@@ -43,7 +43,7 @@
                         
                         <a href="https://docs.google.com/presentation/d/1A0L9bH6cpl7lDfrLmr6zg97ys7dagvPg/edit?slide=id.p39#slide=id.p39" target="_blank">Slides</a><br>
                         
-                        <a href="" target="_blank">YouTube</a><br>
+                        <a href="https://www.youtube.com/watch?v=_GMenT2mLnA" target="_blank">YouTube</a><br>
                         
                         <a href="" target="_blank">MediaService</a>
                         
@@ -77,9 +77,9 @@
                         
                         <a href="./documents/slides/lec1.intro.pdf" target="_blank">Slides</a><br>
                         
-                        <a href="" target="_blank">YouTube</a><br>
+                        <a href="https://www.youtube.com/watch?v=40Ql7hdaJfU" target="_blank">YouTube</a><br>
                         
-                        <a href="" target="_blank">MediaService</a>
+                        <a href="https://mediaservices.cmu.edu/media/Introduction%20to%20Deep%20Learning%20-%20Fall%202026%20-%20Neural%20Networks%20/1_bxa916zk/415066862" target="_blank">MediaService</a>
                         
                     </td>
                     <td>

--- a/F26/pages/tables/lectures_table.html
+++ b/F26/pages/tables/lectures_table.html
@@ -41,9 +41,9 @@
                     </td>
                     <td>
                         
-                        <a href="https://docs.google.com/presentation/d/1A0L9bH6cpl7lDfrLmr6zg97ys7dagvPg/edit?slide=id.p39#slide=id.p39" target="_blank">Slides</a><br>
+                        <a href="https://docs.google.com/presentation/d/1A0L9bH6cpl7lDfrLmr6zg97ys7dagvPg/edit?slide=id.p39#slide=id.p39" target="_blank" rel="noopener noreferrer">Slides</a><br>
                         
-                        <a href="https://www.youtube.com/watch?v=_GMenT2mLnA" target="_blank">YouTube</a>
+                        <a href="https://www.youtube.com/watch?v=_GMenT2mLnA" target="_blank" rel="noopener noreferrer">YouTube</a>
                         
                     </td>
                     <td>
@@ -73,11 +73,11 @@
                     </td>
                     <td>
                         
-                        <a href="./documents/slides/lec1.intro.pdf" target="_blank">Slides</a><br>
+                        <a href="./documents/slides/lec1.intro.pdf" target="_blank" rel="noopener noreferrer">Slides</a><br>
                         
-                        <a href="https://www.youtube.com/watch?v=40Ql7hdaJfU" target="_blank">YouTube</a><br>
+                        <a href="https://www.youtube.com/watch?v=40Ql7hdaJfU" target="_blank" rel="noopener noreferrer">YouTube</a><br>
                         
-                        <a href="https://mediaservices.cmu.edu/media/Introduction%20to%20Deep%20Learning%20-%20Fall%202026%20-%20Neural%20Networks%20/1_bxa916zk/415066862" target="_blank">MediaService</a>
+                        <a href="https://mediaservices.cmu.edu/media/Introduction%20to%20Deep%20Learning%20-%20Fall%202026%20-%20Neural%20Networks%20/1_bxa916zk/415066862" target="_blank" rel="noopener noreferrer">MediaService</a>
                         
                     </td>
                     <td>

--- a/F26/pages/tables_data/lectures.yaml
+++ b/F26/pages/tables_data/lectures.yaml
@@ -11,7 +11,7 @@ lectures:
   - text: "Slides"
     url: "https://docs.google.com/presentation/d/1A0L9bH6cpl7lDfrLmr6zg97ys7dagvPg/edit?slide=id.p39#slide=id.p39"
   - text: "YouTube"
-    url: ""
+    url: "https://www.youtube.com/watch?v=_GMenT2mLnA"
   - text: "MediaService"
     url: ""
   additional_materials: []
@@ -26,9 +26,9 @@ lectures:
   - text: "Slides"
     url: "./documents/slides/lec1.intro.pdf"
   - text: "YouTube"
-    url: ""
+    url: "https://www.youtube.com/watch?v=40Ql7hdaJfU"
   - text: "MediaService"
-    url: ""
+    url: "https://mediaservices.cmu.edu/media/Introduction%20to%20Deep%20Learning%20-%20Fall%202026%20-%20Neural%20Networks%20/1_bxa916zk/415066862"
   additional_materials: []
   quiz:
     text: ''

--- a/F26/pages/tables_data/lectures.yaml
+++ b/F26/pages/tables_data/lectures.yaml
@@ -12,8 +12,6 @@ lectures:
     url: "https://docs.google.com/presentation/d/1A0L9bH6cpl7lDfrLmr6zg97ys7dagvPg/edit?slide=id.p39#slide=id.p39"
   - text: "YouTube"
     url: "https://www.youtube.com/watch?v=_GMenT2mLnA"
-  - text: "MediaService"
-    url: ""
   additional_materials: []
   quiz:
     text: ''

--- a/F26/pages/tables_templates/lectures_table_template.html
+++ b/F26/pages/tables_templates/lectures_table_template.html
@@ -39,13 +39,13 @@
                     </td>
                     <td>
                         {% for item in lecture.slides_videos %}
-                        <a href="{{ item.url }}" target="_blank">{{ item.text }}</a>{% if not loop.last %}<br>{% endif
+                        <a href="{{ item.url }}" target="_blank" rel="noopener noreferrer">{{ item.text }}</a>{% if not loop.last %}<br>{% endif
                         %}
                         {% endfor %}
                     </td>
                     <td>
                         {% for item in lecture.additional_materials %}
-                        <a href="{{ item.url }}" target="_blank">{{ item.text | replace('\n', '<br>') | safe }}</a>{% if
+                        <a href="{{ item.url }}" target="_blank" rel="noopener noreferrer">{{ item.text | replace('\n', '<br>') | safe }}</a>{% if
                         not loop.last %}<br>{% endif %}
                         {% endfor %}
                     </td>
@@ -53,7 +53,7 @@
                     <td rowspan="{{ lecture.quiz.rowspan | default(1) }}"
                         style="vertical-align: middle; text-align: center;">
                         {% if lecture.quiz.url %}
-                        <a href="{{ lecture.quiz.url }}" target="_blank">{{ lecture.quiz.text }}</a>
+                        <a href="{{ lecture.quiz.url }}" target="_blank" rel="noopener noreferrer">{{ lecture.quiz.text }}</a>
                         {% else %}
                         {{ lecture.quiz.text }}
                         {% endif %}


### PR DESCRIPTION
## Summary
- add the Lecture 0 YouTube recording beside its existing Slides link
- populate the Lecture 1 YouTube and MediaService recordings beside its existing Slides link
- remove the empty Lecture 0 MediaService placeholder
- regenerate the Fall 2026 lecture table
- add noopener and noreferrer protection to lecture-table links opened in new tabs

## Verification
- confirmed all five Lecture 0-1 resource URLs in the generated lecture table
- confirmed generated target=_blank links include rel=noopener noreferrer
- ran git diff --check