### PR TITLE
Add F26 lecture 2 video links

### DIFF
--- a/F26/pages/tables/lectures_table.html
+++ b/F26/pages/tables/lectures_table.html
@@ -107,7 +107,11 @@
                     </td>
                     <td>
                         
-                        <a href="./documents/slides/lec2.universal.pdf" target="_blank" rel="noopener noreferrer">Slides</a>
+                        <a href="./documents/slides/lec2.universal.pdf" target="_blank" rel="noopener noreferrer">Slides</a><br>
+
+                        <a href="https://youtu.be/ZEpUYyNi9RA" target="_blank" rel="noopener noreferrer">YouTube</a><br>
+
+                        <a href="https://mediaservices.cmu.edu/media/Introduction+to+Deep+Learning+-+Fall+2026+-+Neural+Networks%2C+What+a+network+can+represent/1_zsm34x4s/415066862" target="_blank" rel="noopener noreferrer">MediaService</a>
                         
                     </td>
                     <td>

--- a/F26/pages/tables/lectures_table.html
+++ b/F26/pages/tables/lectures_table.html
@@ -77,7 +77,7 @@
                         
                         <a href="https://www.youtube.com/watch?v=40Ql7hdaJfU" target="_blank" rel="noopener noreferrer">YouTube</a><br>
                         
-                        <a href="https://mediaservices.cmu.edu/media/Introduction%20to%20Deep%20Learning%20-%20Fall%202026%20-%20Neural%20Networks%20/1_bxa916zk/415066862" target="_blank" rel="noopener noreferrer">MediaService</a>
+                        <a href="https://mediaservices.cmu.edu/media/Introduction%20to%20Deep%20Learning%20-%20Fall%202026%20-%20Neural%20Networks%20/1_bxa916zk/415066862" target="_blank" rel="noopener noreferrer">MediaServices</a>
                         
                     </td>
                     <td>
@@ -109,9 +109,9 @@
                         
                         <a href="./documents/slides/lec2.universal.pdf" target="_blank" rel="noopener noreferrer">Slides</a><br>
 
-                        <a href="https://youtu.be/ZEpUYyNi9RA" target="_blank" rel="noopener noreferrer">YouTube</a><br>
+                        <a href="https://www.youtube.com/watch?v=ZEpUYyNi9RA" target="_blank" rel="noopener noreferrer">YouTube</a><br>
 
-                        <a href="https://mediaservices.cmu.edu/media/Introduction+to+Deep+Learning+-+Fall+2026+-+Neural+Networks%2C+What+a+network+can+represent/1_zsm34x4s/415066862" target="_blank" rel="noopener noreferrer">MediaService</a>
+                        <a href="https://mediaservices.cmu.edu/media/Introduction+to+Deep+Learning+-+Fall+2026+-+Neural+Networks%2C+What+a+network+can+represent/1_zsm34x4s/415066862" target="_blank" rel="noopener noreferrer">MediaServices</a>
                         
                     </td>
                     <td>

--- a/F26/pages/tables_data/lectures.yaml
+++ b/F26/pages/tables_data/lectures.yaml
@@ -25,7 +25,7 @@ lectures:
     url: "./documents/slides/lec1.intro.pdf"
   - text: "YouTube"
     url: "https://www.youtube.com/watch?v=40Ql7hdaJfU"
-  - text: "MediaService"
+  - text: "MediaServices"
     url: "https://mediaservices.cmu.edu/media/Introduction%20to%20Deep%20Learning%20-%20Fall%202026%20-%20Neural%20Networks%20/1_bxa916zk/415066862"
   additional_materials: []
   quiz:
@@ -39,8 +39,8 @@ lectures:
   - text: "Slides"
     url: "./documents/slides/lec2.universal.pdf"
   - text: "YouTube"
-    url: "https://youtu.be/ZEpUYyNi9RA"
-  - text: "MediaService"
+    url: "https://www.youtube.com/watch?v=ZEpUYyNi9RA"
+  - text: "MediaServices"
     url: "https://mediaservices.cmu.edu/media/Introduction+to+Deep+Learning+-+Fall+2026+-+Neural+Networks%2C+What+a+network+can+represent/1_zsm34x4s/415066862"
   additional_materials:
   - text: "IIT CS6840: Size and Depth Complexity of Boolean Circuits"

--- a/F26/pages/tables_data/lectures.yaml
+++ b/F26/pages/tables_data/lectures.yaml
@@ -38,6 +38,10 @@ lectures:
   slides_videos:
   - text: "Slides"
     url: "./documents/slides/lec2.universal.pdf"
+  - text: "YouTube"
+    url: "https://youtu.be/ZEpUYyNi9RA"
+  - text: "MediaService"
+    url: "https://mediaservices.cmu.edu/media/Introduction+to+Deep+Learning+-+Fall+2026+-+Neural+Networks%2C+What+a+network+can+represent/1_zsm34x4s/415066862"
   additional_materials:
   - text: "IIT CS6840: Size and Depth Complexity of Boolean Circuits"
     url: "./documents/readings/booleancircuits_shannonproof.pdf"


### PR DESCRIPTION
## Summary
- add YouTube and MediaService links for Fall 2026 Lecture 2
- regenerate the F26 lectures table HTML

## Verification
- `git diff --check`
- confirmed both links appear in the generated lecture table

## Tests
- not run (content-only update)