### PR TITLE
Add F26 Lab 2 video links

### DIFF
--- a/F26/pages/tables/recitations.html
+++ b/F26/pages/tables/recitations.html
@@ -1164,7 +1164,7 @@
                      
                         
                             
-                            <a href="https://youtu.be/ed74ViuofcY" target="_blank" rel="noopener noreferrer">YouTube</a><br> 
+                            <a href="https://www.youtube.com/watch?v=ed74ViuofcY" target="_blank" rel="noopener noreferrer">YouTube</a><br> 
                         
                             
                             <a href="https://mediaservices.cmu.edu/media/Introduction%20to%20Deep%20Learning%20-%20Fall%202026%20-Recitation%203/1_h2ft6mvz/415066862" target="_blank" rel="noopener noreferrer">MediaServices</a> 

--- a/F26/pages/tables/recitations.html
+++ b/F26/pages/tables/recitations.html
@@ -1154,7 +1154,26 @@
             
             
             
-            <td style="vertical-align: middle; text-align: left;"></td>
+            
+                 
+                 
+                 
+                
+                <td rowspan="1" style="vertical-align: middle; text-align: left;">
+                     
+                     
+                        
+                            
+                            <a href="https://youtu.be/ed74ViuofcY" target="_blank" rel="noopener noreferrer">YouTube</a><br> 
+                        
+                            
+                            <a href="https://mediaservices.cmu.edu/media/Introduction%20to%20Deep%20Learning%20-%20Fall%202026%20-Recitation%203/1_h2ft6mvz/415066862" target="_blank" rel="noopener noreferrer">MediaServices</a> 
+                        
+                     
+                </td>
+                
+                
+            
             
 
             

--- a/F26/pages/tables_data/recitations.yaml
+++ b/F26/pages/tables_data/recitations.yaml
@@ -385,7 +385,11 @@ recitations:
     date: "Friday,<br> Sep 4"
     topics: "Debugging"
     materials: []
-    videos: []
+    videos:
+      - text: "YouTube"
+        url: "https://youtu.be/ed74ViuofcY"
+      - text: "MediaServices"
+        url: "https://mediaservices.cmu.edu/media/Introduction%20to%20Deep%20Learning%20-%20Fall%202026%20-Recitation%203/1_h2ft6mvz/415066862"
     authors: ""
   - title: "Hackathon 2"
     date: "Saturday,<br> Sep 5"

--- a/F26/pages/tables_data/recitations.yaml
+++ b/F26/pages/tables_data/recitations.yaml
@@ -387,7 +387,7 @@ recitations:
     materials: []
     videos:
       - text: "YouTube"
-        url: "https://youtu.be/ed74ViuofcY"
+        url: "https://www.youtube.com/watch?v=ed74ViuofcY"
       - text: "MediaServices"
         url: "https://mediaservices.cmu.edu/media/Introduction%20to%20Deep%20Learning%20-%20Fall%202026%20-Recitation%203/1_h2ft6mvz/415066862"
     authors: ""


### PR DESCRIPTION
## Summary
- Add the Lab 2 YouTube recording link.
- Add the Lab 2 MediaServices recording link.
- Regenerate the committed recitations table.