### PR TITLE
Clarify Fall 2026 homework bonus policy

### DIFF
--- a/F26/pages/syllabus.html
+++ b/F26/pages/syllabus.html
@@ -62,15 +62,17 @@
                                         and submitted
                                         on <b><a href="https://www.gradescope.com/courses/1315509">Gradescope</a></b>.
                                     </li>
-                                    <li> Each HWxP1 has a "on-time" deadline. HWxP1s are evaluated based on
-                                        the number of correctly completed parts submitted to Gradescope by this
-                                        deadline.
+                                    <li> Each HWxP1 has an "early" and an "on-time" deadline. You will receive a 3%
+                                        bonus on your HWxP1 score if you earn a full score by the early submission
+                                        deadline. Otherwise, HWxP1s are evaluated based on the number of correctly
+                                        completed parts submitted to Gradescope by the on-time deadline.
                                     </li>
                                     <li> Each HWxP2 has 3 deadlines: "early", "on-time" and "late/slack".
                                         <ul>
                                             <li> <b>Early submission deadline:</b> You are required to make at least
-                                                one submission to Kaggle by this deadline to receive a 3 % bonus points.
-                                                This is intended to encourage students to begin their work early.
+                                                one submission to Kaggle that meets the minimum cutoff by this
+                                                deadline. Otherwise, a 3% penalty will be applied to your final HWxP2
+                                                score. This is intended to encourage students to begin their work early.
                                             </li>
                                             <li> <b>On-time deadline:</b> This is the usual deadline for HWxP2
                                                 submissions.
@@ -97,11 +99,11 @@
                                         </b>.<br>
                                         Scores will be interpolated linearly between these cutoffs.
                                     </li>
-                                    <li>There are bonus assignments for each HW. Bonus points (5% total) contribute to
-                                        the final score by adding on top of the base score. Notice that bonus scores for
-                                        11485 and 11685/785 are different. 11485 Base Score = Assignments (50%) + Quiz
-                                        (24%) + Attendance (1%) = 75% and 11685/785 Base Score = 11485 Base Score (75%)
-                                        + Project (25%) = 100%.
+                                    <li>HWx Bonus and HWx Autograd assignments are bonuses that add to your final base
+                                        score. Details of the bonus calculation and cumulative cap will be announced.
+                                        Notice that bonus scores for 11485 and 11685/785 are different. 11485 Base
+                                        Score = Assignments (50%) + Quiz (24%) + Attendance (1%) = 75% and 11685/785
+                                        Base Score = 11485 Base Score (75%) + Project (25%) = 100%.
                                     </li>
                                 </ul>
                             </td>


### PR DESCRIPTION
## Summary
- document the 3% HWxP1 early-submission bonus and full-score requirement
- document the HWxP2 early minimum-cutoff requirement and 3% penalty
- clarify that HWx Bonus and Autograd assignments add to the final base score, with calculation and cap details forthcoming

## Validation
- git diff --check
- confirmed F26/index.html loads F26/pages/syllabus.html directly, so regeneration is not required