### PR TITLE
Add Lab 3 YouTube link

### DIFF
--- a/F26/pages/tables/recitations.html
+++ b/F26/pages/tables/recitations.html
@@ -1309,7 +1309,23 @@
             
             
             
-            <td style="vertical-align: middle; text-align: left;"></td>
+            
+                 
+                 
+                 
+                
+                <td rowspan="1" style="vertical-align: middle; text-align: left;">
+                     
+                     
+                        
+                            
+                            <a href="https://www.youtube.com/watch?v=m5R8_EJjhg8" target="_blank" rel="noopener noreferrer">YouTube</a> 
+                        
+                     
+                </td>
+                
+                
+            
             
 
             

--- a/F26/pages/tables_data/recitations.yaml
+++ b/F26/pages/tables_data/recitations.yaml
@@ -401,7 +401,9 @@ recitations:
     date: "Saturday,<br> Sep 12"
     topics: "Ablations, Hyperparameter Tuning Methods, Normalizations"
     materials: []
-    videos: []
+    videos:
+      - text: "YouTube"
+        url: "https://www.youtube.com/watch?v=m5R8_EJjhg8"
     authors: ""
   - title: "Lab 4"
     date: "Friday,<br> Sep 18"


### PR DESCRIPTION
Adds the YouTube recording link for F26 Lab 3 + Hackathon 3 and regenerates the recitations table.